### PR TITLE
TASK // Neos 7+ compatibility

### DIFF
--- a/Classes/Command/MultisiteCommandController.php
+++ b/Classes/Command/MultisiteCommandController.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Flownative\Neos\MultisiteHelper\Command;
 
 /*
@@ -13,6 +14,8 @@ namespace Flownative\Neos\MultisiteHelper\Command;
 
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Cli\CommandController;
+use Neos\Flow\ObjectManagement\Exception\UnresolvedDependenciesException;
+use Neos\Flow\Persistence\Exception\IllegalObjectTypeException;
 use Neos\Media\Domain\Model\AssetCollection;
 use Neos\Media\Domain\Repository\AssetCollectionRepository;
 use Neos\Neos\Domain\Model\Site;
@@ -42,8 +45,9 @@ class MultisiteCommandController extends CommandController
      *
      * @param string $siteNodeName
      * @return void
+     * @throws IllegalObjectTypeException|UnresolvedDependenciesException
      */
-    public function setupCommand($siteNodeName)
+    public function setupCommand($siteNodeName): void
     {
         $assetCollectionTitle = ucfirst($siteNodeName);
         $assetCollection = $this->assetCollectionRepository->findOneByTitle($assetCollectionTitle);

--- a/Classes/PersistedUsernamePasswordProvider.php
+++ b/Classes/PersistedUsernamePasswordProvider.php
@@ -13,9 +13,14 @@ namespace Flownative\Neos\MultisiteHelper;
 
 use Doctrine\ORM\EntityNotFoundException;
 use Neos\Flow\Annotations as Flow;
+use Neos\Flow\Persistence\Exception\IllegalObjectTypeException;
 use Neos\Flow\Security\Authentication\AuthenticationManagerInterface;
 use Neos\Flow\Security\Authentication\Provider\PersistedUsernamePasswordProvider as FlowPersistedUsernamePasswordProvider;
 use Neos\Flow\Security\Authentication\TokenInterface;
+use Neos\Flow\Security\Exception;
+use Neos\Flow\Security\Exception\InvalidAuthenticationStatusException;
+use Neos\Flow\Security\Exception\NoSuchRoleException;
+use Neos\Flow\Security\Exception\UnsupportedAuthenticationTokenException;
 use Neos\Flow\Security\Policy\PolicyService;
 use Neos\Neos\Domain\Repository\DomainRepository;
 use Neos\Utility\ObjectAccess;
@@ -56,8 +61,13 @@ class PersistedUsernamePasswordProvider extends FlowPersistedUsernamePasswordPro
      *
      * @param TokenInterface $authenticationToken The token to be authenticated
      * @return void
+     * @throws IllegalObjectTypeException
+     * @throws Exception
+     * @throws InvalidAuthenticationStatusException
+     * @throws NoSuchRoleException
+     * @throws UnsupportedAuthenticationTokenException
      */
-    public function authenticate(TokenInterface $authenticationToken)
+    public function authenticate(TokenInterface $authenticationToken): void
     {
         parent::authenticate($authenticationToken);
         if (!$authenticationToken->getAuthenticationStatus() === TokenInterface::AUTHENTICATION_SUCCESSFUL) {
@@ -90,7 +100,7 @@ class PersistedUsernamePasswordProvider extends FlowPersistedUsernamePasswordPro
      * @param TokenInterface $authenticationToken
      * @return void
      */
-    protected function rollback(TokenInterface $authenticationToken)
+    protected function rollback(TokenInterface $authenticationToken): void
     {
         $authenticationToken->setAuthenticationStatus(TokenInterface::WRONG_CREDENTIALS);
         ObjectAccess::setProperty($this->authenticationManager, 'isAuthenticated', false, true);

--- a/Classes/PersistedUsernamePasswordProvider.php
+++ b/Classes/PersistedUsernamePasswordProvider.php
@@ -13,13 +13,13 @@ namespace Flownative\Neos\MultisiteHelper;
 
 use Doctrine\ORM\EntityNotFoundException;
 use Neos\Flow\Annotations as Flow;
-use Neos\Flow\Log\SecurityLoggerInterface;
 use Neos\Flow\Security\Authentication\AuthenticationManagerInterface;
 use Neos\Flow\Security\Authentication\Provider\PersistedUsernamePasswordProvider as FlowPersistedUsernamePasswordProvider;
 use Neos\Flow\Security\Authentication\TokenInterface;
 use Neos\Flow\Security\Policy\PolicyService;
 use Neos\Neos\Domain\Repository\DomainRepository;
 use Neos\Utility\ObjectAccess;
+use Psr\Log\LoggerInterface;
 
 /**
  * A custom site aware authentication provider extending the existing persisted username password provider
@@ -45,8 +45,8 @@ class PersistedUsernamePasswordProvider extends FlowPersistedUsernamePasswordPro
     protected $policyService;
 
     /**
-     * @Flow\Inject
-     * @var SecurityLoggerInterface
+     * @Flow\Inject(name="Neos.Flow:SecurityLogger")
+     * @var LoggerInterface
      */
     protected $securityLogger;
 

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "description": "Tooling for use in a multi-site Neos setup.",
     "license": "MIT",
     "require": {
-        "neos/neos": "^4.0 || ^5.0 || ^7.0 || ^8.0"
+        "neos/neos": "^7.0 || ^8.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "description": "Tooling for use in a multi-site Neos setup.",
     "license": "MIT",
     "require": {
-        "neos/neos": "^4.0 || ^5.0"
+        "neos/neos": "^4.0 || ^5.0 || ^7.0 || ^8.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
- Adjust required neos version from "^4.0 || ^5.0" to "^7.0 || ^8.0"
- Refactor deprecated logger implementation

Tested with Neos 8.3.6